### PR TITLE
AGR-572  Common mapping across searchable documents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>2.8.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
 			<version>2.8.2</version>
 		</dependency>
@@ -56,7 +51,25 @@
          <groupId>org.elasticsearch.client</groupId>
          <artifactId>x-pack-transport</artifactId>
          <version>5.5.2</version>
-      </dependency>
+        </dependency>
+		<dependency>
+			<groupId>org.codehaus.groovy</groupId>
+			<artifactId>groovy-all</artifactId>
+			<version>2.4.4</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.spockframework</groupId>
+			<artifactId>spock-core</artifactId>
+			<version>1.0-groovy-2.4</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.arquillian.spock</groupId>
+			<artifactId>arquillian-spock-example-groovy-2.x</artifactId>
+			<version>1.0.0.Beta3</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	
 	<repositories>
@@ -119,6 +132,67 @@
 						</goals>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.gmavenplus</groupId>
+				<artifactId>gmavenplus-plugin</artifactId>
+				<version>1.0</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>generateStubs</goal>
+							<goal>compile</goal>
+							<goal>testGenerateStubs</goal>
+							<goal>testCompile</goal>
+						</goals>
+					</execution>
+				</executions>
+				<dependencies>
+					<dependency>
+						<groupId>org.codehaus.groovy</groupId>
+						<artifactId>groovy-all</artifactId>
+						<version>2.4.4</version>
+						<scope>runtime</scope>
+					</dependency>
+				</dependencies>
+			</plugin>
+			<!-- this runs unit tests -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.16</version>
+				<configuration>
+					<parallel>methods</parallel>
+					<threadCount>5</threadCount>
+					<excludes>
+						<exclude>**/IntegrationSpec.*</exclude>
+						<exclude>**/Abstract*.java</exclude>
+					</excludes>
+					<includes>
+						<include>**/*Test.*</include>
+						<!--<include>**/*Spec.*</include>-->
+					</includes>
+				</configuration>
+			</plugin>
+			<!-- this runs integration tests -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>2.19.1</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<includes>
+						<include>**/*IntegrationSpec.groovy</include>
+						<include>**/*IntegrationSpec.java</include>
+					</includes>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/org/alliancegenome/indexer/document/GoDocument.java
+++ b/src/main/java/org/alliancegenome/indexer/document/GoDocument.java
@@ -18,7 +18,7 @@ public class GoDocument extends ESDocument {
 	
 	private String id;
 	private String go_type;
-	private List<String> go_synonyms;
+	private List<String> synonyms;
 	private List<String> go_genes;
 	private List<String> go_species;
 

--- a/src/main/java/org/alliancegenome/indexer/schema/Mappings.java
+++ b/src/main/java/org/alliancegenome/indexer/schema/Mappings.java
@@ -18,9 +18,7 @@ public abstract class Mappings extends Builder {
 		if(symbol || autocomplete || keyword) {
 			builder.startObject("fields");
 			if(keyword) {
-				//temporarily index into both raw & keyword, for backwards compatibility with api repo
 				buildProperty("keyword", "keyword");
-				buildProperty("raw", "keyword");
 			}
 			if(symbol) buildGenericField("symbol", "text", "symbols", false, false, false);
 			if(autocomplete) buildProperty("autocomplete", "text", "autocomplete", "autocomplete_search");
@@ -44,6 +42,21 @@ public abstract class Mappings extends Builder {
 		if(search_analyzer != null) builder.field("search_analyzer", search_analyzer);
 		builder.endObject();
 	}
-	
+
+	//Mappings that must be shared / equivalent across searchable documents
+	protected void buildSharedSearchableDocumentMappings() throws IOException {
+
+		buildProperty("primaryId", "keyword");
+		buildGenericField("category", "keyword", null, true, false, true);
+		buildGenericField("name", "text", null, true, true, true);
+		buildGenericField("name_key", "text", "symbols", false, true, false);
+		buildGenericField("synonyms", "text", "symbols", false, true, true);
+		buildProperty("external_ids", "text", "symbols");
+		buildProperty("href", "text", "symbols");
+		buildProperty("id", "text", "symbols");
+		buildProperty("description", "text");
+		buildGenericField("species", "text", null, false, false, true);
+
+	}
 	
 }

--- a/src/main/java/org/alliancegenome/indexer/schema/mappings/DiseaseMappings.java
+++ b/src/main/java/org/alliancegenome/indexer/schema/mappings/DiseaseMappings.java
@@ -18,13 +18,13 @@ public class DiseaseMappings extends Mappings {
 
             builder.startObject("properties");
 
+            buildSharedSearchableDocumentMappings();
+
             buildGenericField("geneDocument.symbol", "string", null, false, false, true);
             buildGenericField("disease_species.orderID", "long", null, false, false, true);
             buildGenericField("diseaseID", "string", null, false, false, true);
             buildGenericField("diseaseName", "string", null, false, false, true);
             buildGenericField("parentDiseaseIDs", "string", null, false, false, true);
-            buildProperty("primaryId", "keyword");
-            buildProperty("external_ids", "text", "symbols");
 
             builder.endObject();
 

--- a/src/main/java/org/alliancegenome/indexer/schema/mappings/GeneMappings.java
+++ b/src/main/java/org/alliancegenome/indexer/schema/mappings/GeneMappings.java
@@ -16,15 +16,13 @@ public class GeneMappings extends Mappings {
 			builder.startObject();
 				builder.startObject("properties");
 
-					buildProperty("id", "text", "symbols");
+					buildSharedSearchableDocumentMappings();
+
 					buildProperty("systematicName", "text", "symbols");
 					buildCrossReferencesField();
 					buildMetaDataField();
-					buildGenericField("category", "keyword", null, true, false, true);
-					
-					buildProperty("description", "text");
+
 					//buildDiseasesField();
-					buildProperty("external_ids", "text", "symbols");
 					buildProperty("geneLiteratureUrl", "keyword");
 					buildProperty("geneSynopsis", "text");
 					buildProperty("geneSynopsisUrl", "keyword");
@@ -32,18 +30,10 @@ public class GeneMappings extends Mappings {
 					buildGenericField("gene_cellular_component", "text", null, true, false, true);
 					buildGenericField("gene_molecular_function", "text", null, true, false, true);
 					buildGenomeLocationsField();
-					buildProperty("href", "text", "symbols");
-					buildGenericField("name", "text", null, true, true, true);
-					buildGenericField("name_key", "text", "symbols", false, true, false);
-					// Orthology
-					buildProperty("primaryId", "keyword");
-					// Release
+
 					buildProperty("secondaryIds", "keyword");
 					buildProperty("soTermId", "keyword");
-					// So Term Name
-					buildGenericField("species", "text", null, false, false, true);
 					buildGenericField("symbol", "text", "symbols", false, true, true);
-					buildGenericField("synonyms", "text", "symbols", false, true, true);
 					buildProperty("taxonId", "keyword");
 					
 				builder.endObject();

--- a/src/main/java/org/alliancegenome/indexer/schema/mappings/GoMappings.java
+++ b/src/main/java/org/alliancegenome/indexer/schema/mappings/GoMappings.java
@@ -14,17 +14,12 @@ public class GoMappings extends Mappings {
 		try {
 			builder.startObject();
 				builder.startObject("properties");
-			
-				buildProperty("description", "text");
+
+				buildSharedSearchableDocumentMappings();
+
 				buildGenericField("go_genes", "text", "symbols", false, false, true);
 				buildGenericField("go_species", "text", null, false, false, true);
 				buildGenericField("go_type", "text", null, false, false, true);
-				
-				buildProperty("href", "text", "symbols");
-				buildProperty("id", "text", "symbols");
-				
-				buildGenericField("name", "text", null, true, true, true);
-				buildGenericField("name_key", "text", "symbols", false, true, false);
 
 				builder.endObject();
 			builder.endObject();

--- a/src/main/java/org/alliancegenome/indexer/translators/GoTranslator.java
+++ b/src/main/java/org/alliancegenome/indexer/translators/GoTranslator.java
@@ -30,7 +30,7 @@ public class GoTranslator extends EntityDocumentTranslator<GOTerm, GoDocument> {
 		for(Synonym s: entity.getSynonyms()) {
 			go_synonyms.add(s.getPrimaryKey());
 		}
-		doc.setGo_synonyms(go_synonyms);
+		doc.setSynonyms(go_synonyms);
 		
 		ArrayList<String> go_species = new ArrayList<>();
 		ArrayList<String> go_genes = new ArrayList<String>();

--- a/src/test/groovy/org/alliancegenome/indexer/CategoriesAndFieldsIntegrationSpec.groovy
+++ b/src/test/groovy/org/alliancegenome/indexer/CategoriesAndFieldsIntegrationSpec.groovy
@@ -1,0 +1,69 @@
+import groovy.json.JsonSlurper
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class CategoriesAndFieldsIntegrationSpec extends Specification {
+
+
+    @Unroll
+    def "There should be some #category documents"() {
+        when: "we search for documents from a category"
+        def total = search("category:$category")?.hits?.total
+        then: "some should come back"
+        total
+        total > 0
+
+        where:
+        category << ["gene", "disease", "go"]
+    }
+
+    @Unroll
+    def "#category docs should have values in #field"() {
+        when: "when we execute a search for documents with values in a field within a category"
+        def query = "category:$category AND $field:[* TO *]"
+        def total = search(query)?.hits?.total
+
+        then: "there should be hits"
+        total
+        total > 0
+
+        where:
+        category  | field
+
+        "gene"    | "primaryId"
+        "gene"    | "category"
+        "gene"    | "name"
+        "gene"    | "name.keyword"
+        "gene"    | "name.autocomplete"
+        "gene"    | "synonyms"
+        "gene"    | "synonyms.autocomplete"
+        "gene"    | "symbol"
+        "gene"    | "symbol.autocomplete"
+
+        "go"      | "primaryId"
+        "go"      | "category"
+        "go"      | "name"
+        "go"      | "name.keyword"
+        "go"      | "name.autocomplete"
+        "go"      | "synonyms"
+        "go"      | "synonyms.autocomplete"
+
+        "disease" | "primaryId"
+        "disease" | "category"
+        "disease" | "name"
+        "disease" | "name.keyword"
+        "disease" | "name.autocomplete"
+        "disease" | "synonyms"
+        "disease" | "synonyms.autocomplete"
+
+
+    }
+
+
+    private def search(String query) {
+        //todo: need to set the ES url in a nicer way
+        query = URLEncoder.encode(query, "UTF-8")
+        def url = new URL("http://localhost:9200/site_index/_search?q=$query")
+        return new JsonSlurper().parseText(url.text)
+    }
+}


### PR DESCRIPTION
*** I haven't tested this!   I don't have a dev environment yet that can fit both the neo database and the indexer, so I ran the indexer against it, but never all the way through.   I'm not sure of the best way to handle that.  Maybe one of you guys can check out this branch and index against it?  

Updated mapping so that main fields for search/autocomplete will be generated by the same code across all of the categories, and threw in anything else that seemed to be common across docs.

I also got a start on a test that will run against ES to confirm that all of the categories are present, and that each field that should be loaded for documents in a category at least has one document with that field filled.

The one thing in here that might break something downstream is that I switched GO terms to just using the 'synonyms' field rather than having their own 'go_synonyms' field, since I can't think of anything in the application that is helped by that. 

Also, mvn verify runs the test, right now it's looking for:

`        category  | field

        "gene"    | "primaryId"
        "gene"    | "category"
        "gene"    | "name"
        "gene"    | "name.keyword"
        "gene"    | "name.autocomplete"
        "gene"    | "synonyms"
        "gene"    | "synonyms.autocomplete"
        "gene"    | "symbol"
        "gene"    | "symbol.autocomplete"

        "go"      | "primaryId"
        "go"      | "category"
        "go"      | "name"
        "go"      | "name.keyword"
        "go"      | "name.autocomplete"
        "go"      | "synonyms"
        "go"      | "synonyms.autocomplete"

        "disease" | "primaryId"
        "disease" | "category"
        "disease" | "name"
        "disease" | "name.keyword"
        "disease" | "name.autocomplete"
        "disease" | "synonyms"
        "disease" | "synonyms.autocomplete"
`

